### PR TITLE
Added has_role_# in addition to the current has_role_X

### DIFF
--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -4562,6 +4562,7 @@ class EE_Template
                 $value = in_array($role->getId(), $assigned_role_ids);
 
                 $vars['has_role_' . $role->short_name] = $value;
+                $vars['has_role_' . $role->role_id] = $value;
             }
         }
 


### PR DESCRIPTION
It would be nice to be able to refer to roles by their numbers as well as by their short names in the conditional has_role_x.  (See discussion #4378)

For example, imagine that I'm echoing each of these variables in a template. It would be useful if the final variable also was a "1" -- that way if I rename a role, the template code doesn't need to be changed.

```
{logged_in_primary_role_id}: 1
{logged_in_primary_role_short_name}: super_admins
{has_role_super_admins}: true
{has_role_1}: true
```

There may be a small chance of collision if some maniac has named a member role as a) only a number (if this is even possible) and b) that number name does not match the member role id number, but frankly, those sorts of people deserve what's coming to them.